### PR TITLE
bugfix localstorage user rent

### DIFF
--- a/app/src/main/java/com/example/sombriyakotlin/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/repository/UserRepositoryImpl.kt
@@ -39,7 +39,7 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun logInUser(credentials: LogInUser): User {
         val respuestaUserDto = userApi.logInUser(credentials.toDto())
         val domainUser = respuestaUserDto.toDomain()
-        //userLocalDataSource.saveUser(domainUser)
+        userLocalDataSource.saveUser(domainUser)
         return domainUser
     }
 


### PR DESCRIPTION
#41 
feat: Enable local user saving on login

The user's information is now saved locally to the device after a successful login. This was previously commented out.