### PR TITLE
feat: Add connectivity check for weather notifications

### DIFF
--- a/app/src/main/java/com/example/sombriyakotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val navController = rememberNavController()
             SombriYaKotlinTheme {
-                AppNavigation(navController = navController, false)
+                AppNavigation(navController = navController, true)
             }
         }
     }


### PR DESCRIPTION
*   Implement `ObserveConnectivityUseCase` in `NotificationsViewModel` to monitor network status.
*   Prevent weather API calls when the device is offline and instead show a "No internet connection" notification.
*   Update the weather notification title to "Riesgo bajo de Lluvia" when the probability of precipitation is low.
*   Enable a feature flag in `MainActivity` by changing the `AppNavigation` parameter to `true`.