### PR TITLE
feat: Add offline support to Chatbot

### DIFF
--- a/app/src/main/java/com/example/sombriyakotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val navController = rememberNavController()
             SombriYaKotlinTheme {
-                AppNavigation(navController = navController, false)
+                AppNavigation(navController = navController, true)
             }
         }
     }

--- a/app/src/main/java/com/example/sombriyakotlin/ui/chatbot/ChatbotScreen.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/chatbot/ChatbotScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -59,6 +60,10 @@ fun ChatbotScreen(
 
     var mensaje by remember { mutableStateOf("") }
 
+    val isConnected by viewModel.isConnected.collectAsState()
+
+
+
     LaunchedEffect(messages.size) {
         if (messages.isNotEmpty()) {
             listState.animateScrollToItem(messages.size - 1)
@@ -72,10 +77,21 @@ fun ChatbotScreen(
             .background(color = colorResource(id = R.color.EstacionCard))
             .navigationBarsPadding()
             .imePadding(),
-        verticalArrangement = Arrangement.Bottom
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally
     )
     {
-        TopBarMini(navController, "Chatbot")
+        TopBarMini(navController, "Sombri-IA")
+        if (!isConnected){
+            Card(
+                Modifier.wrapContentSize().padding(top=10.dp),
+                shape = RoundedCornerShape(50.dp),
+                colors= CardColors(colorResource(R.color.light_gray),colorResource(R.color.black),colorResource(R.color.gray),colorResource(R.color.gray))
+
+            ) {
+                Text("No hay conexión", modifier = Modifier.padding(5.dp))
+            }
+        }
         LazyColumn(
             modifier = Modifier
                 .weight(1f)
@@ -115,7 +131,7 @@ fun ChatbotScreen(
                     .weight(1f)                       // ocupa el espacio sobrante
                     .heightIn(min = 48.dp)            // altura mínima razonable
                     .background(colorResource(id = R.color.white_FFFDFD), shape = RoundedCornerShape(8.dp)),
-                placeholder = { Text("Escribe un mensaje...") },
+                placeholder = { Text(if (isConnected) "Escribe un mensaje..." else "Sin conexión") },
                 singleLine = false,
                 maxLines = 2,                         // límite de líneas para evitar crecer demasiado
                 textStyle = LocalTextStyle.current.copy(fontSize = 16.sp),
@@ -124,12 +140,12 @@ fun ChatbotScreen(
 
             val isLoading = uiState is ChatbotViewModel.ChatState.Loading
             Button({
-                if (mensaje.isNotBlank() && !isLoading) {
+                if (mensaje.isNotBlank() && !isLoading && isConnected) {
                     viewModel.sendMessage(mensaje)
                     mensaje = ""
                 }
             },
-                enabled = !isLoading,
+                enabled = !isLoading && isConnected,
                 modifier = Modifier.padding(start = 1.dp, end = 10.dp)
                 ,
                 colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/example/sombriyakotlin/ui/chatbot/ChatbotViewModel.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/chatbot/ChatbotViewModel.kt
@@ -8,6 +8,7 @@ import com.example.sombriyakotlin.domain.model.Chat
 import com.example.sombriyakotlin.domain.model.Message
 import com.example.sombriyakotlin.domain.model.User
 import com.example.sombriyakotlin.domain.repository.ChatbotRepository
+import com.example.sombriyakotlin.domain.usecase.ObserveConnectivityUseCase
 import com.example.sombriyakotlin.domain.usecase.chatbot.ChatbotUseCases
 import com.example.sombriyakotlin.ui.account.ProfileScreenViewModel.ProfileState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,8 +19,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ChatbotViewModel @Inject constructor(
-    private val chatbotUseCases: ChatbotUseCases,
-    private val chatbotRepository: ChatbotRepository
+    private val chatbotRepository: ChatbotRepository,
+    observeConnectivity: ObserveConnectivityUseCase
 ): ViewModel()
 {
     sealed class ChatState {
@@ -28,6 +29,8 @@ class ChatbotViewModel @Inject constructor(
         data class Success(val chat: Chat) : ChatState()
         data class Error(val message: String) : ChatState()
     }
+
+    val isConnected: StateFlow<Boolean> = observeConnectivity()
 
     private val _chatbotState = MutableStateFlow<ChatState>(ChatState.Idle)
     val chatbotState: StateFlow<ChatState> = _chatbotState

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,6 +26,7 @@
     <color name="light_blue">#ADD8E6</color>
     <color name="green">#4CAF50</color>
     <color name="naranja_light">#E6BFAC</color>
+    <color name="light_gray">#688691</color>
 
 
 </resources>


### PR DESCRIPTION
#81 
*   Implement `ObserveConnectivityUseCase` in `ChatbotViewModel` to track network status.
*   Update `ChatbotScreen` UI to reflect connectivity changes:
    *   Display a "No hay conexión" (`No connection`) chip when offline.
    *   Disable the message input field and send button when disconnected.
    *   Rename TopBar title to "Sombri-IA".
*   Add a new `light_gray` color resource.