### PR TITLE
feat: Implement location consent flow and tracking logic

### DIFF
--- a/app/src/main/java/com/example/sombriyakotlin/data/datasource/DataStoreSettingsStorage.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/datasource/DataStoreSettingsStorage.kt
@@ -1,0 +1,35 @@
+package com.example.sombriyakotlin.data.datasource
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class DataStoreSettingsStorage(
+    private val dataStore: DataStore<Preferences>
+)  {
+
+    private val KEY_LOCATION_CONSENT = booleanPreferencesKey("location_consent_given") // true/false
+    private val KEY_LOCATION_CONSENT_ASKED = booleanPreferencesKey("location_consent_asked") // si ya preguntó
+
+    fun isLocationConsentGiven(): Flow<Boolean?> =
+        dataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .map { prefs ->
+                if (!prefs.contains(KEY_LOCATION_CONSENT_ASKED)) null
+                else prefs[KEY_LOCATION_CONSENT] ?: false
+            }
+
+    suspend fun setLocationConsent(given: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_LOCATION_CONSENT] = given
+            prefs[KEY_LOCATION_CONSENT_ASKED] = true
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/sombriyakotlin/data/di/DataSourceModule.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/di/DataSourceModule.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.room.Room
 import com.example.sombriyakotlin.data.datasource.AppDatabase
+import com.example.sombriyakotlin.data.datasource.DataStoreSettingsStorage
 import com.example.sombriyakotlin.data.datasource.HistoryDao
 import com.example.sombriyakotlin.data.datasource.UserLocalDataSource
 import com.example.sombriyakotlin.data.repository.HistoryRepositoryImpl
@@ -33,6 +34,13 @@ object DataSourceModule {
             context.preferencesDataStoreFile(USER_PREFERENCES)
         }
     }
+
+    @Provides
+    @Singleton
+    fun provideDataStoreSettingsStorage(
+        dataStore: DataStore<Preferences>
+    ): DataStoreSettingsStorage= DataStoreSettingsStorage(dataStore)
+
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/example/sombriyakotlin/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/di/NetworkModule.kt
@@ -1,9 +1,10 @@
 package com.example.sombriyakotlin.data.di
 
 import com.example.sombriyakotlin.BuildConfig
-import com.example.sombriyakotlin.data.api.RentalApi
-import com.example.sombriyakotlin.data.api.StationApi
-import com.example.sombriyakotlin.data.api.UserApi
+import com.example.sombriyakotlin.data.serviceAdapter.LocationApi
+import com.example.sombriyakotlin.data.serviceAdapter.RentalApi
+import com.example.sombriyakotlin.data.serviceAdapter.StationApi
+import com.example.sombriyakotlin.data.serviceAdapter.UserApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -43,6 +44,9 @@ object NetworkModule {
     fun provideStationApi(retrofit: Retrofit): StationApi =
         retrofit.create(StationApi::class.java)
 
+    @Provides @Singleton
+    fun provideLocationApi(retrofit: Retrofit): LocationApi =
+        retrofit.create(LocationApi::class.java)
 
     @Provides @Singleton
     @Named("OWM_API_KEY")

--- a/app/src/main/java/com/example/sombriyakotlin/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/di/RepositoryModule.kt
@@ -1,22 +1,24 @@
 package com.example.sombriyakotlin.data.di
 
-import com.example.sombriyakotlin.BuildConfig
-import com.example.sombriyakotlin.data.api.RentalApi
-import com.example.sombriyakotlin.data.api.StationApi
-import com.example.sombriyakotlin.data.api.UserApi
+import com.example.sombriyakotlin.data.serviceAdapter.RentalApi
+import com.example.sombriyakotlin.data.serviceAdapter.StationApi
+import com.example.sombriyakotlin.data.serviceAdapter.UserApi
 import com.example.sombriyakotlin.data.cache.LruCache
+import com.example.sombriyakotlin.data.datasource.DataStoreSettingsStorage
 import com.example.sombriyakotlin.data.datasource.RentalLocalDataSource
 import com.example.sombriyakotlin.data.datasource.UserLocalDataSource
 import com.example.sombriyakotlin.data.network.NetworkRepositoryImpl
 import com.example.sombriyakotlin.data.repository.ChatbotRepositoryImpl
 import com.example.sombriyakotlin.data.repository.HistoryRepositoryImpl
+import com.example.sombriyakotlin.data.repository.LocationRepositoryImpl
 import com.example.sombriyakotlin.data.repository.RentalRepositoryImpl
 import com.example.sombriyakotlin.data.repository.StationRepositoryImpl
 import com.example.sombriyakotlin.data.repository.UserRepositoryImpl
-import com.example.sombriyakotlin.domain.model.Localization
+import com.example.sombriyakotlin.data.serviceAdapter.LocationApi
 import com.example.sombriyakotlin.domain.model.Station
 import com.example.sombriyakotlin.domain.repository.ChatbotRepository
 import com.example.sombriyakotlin.domain.repository.HistoryRepository
+import com.example.sombriyakotlin.domain.repository.LocationRepository
 import com.example.sombriyakotlin.domain.repository.NetworkRepository
 import com.example.sombriyakotlin.domain.repository.RentalRepository
 import com.example.sombriyakotlin.domain.repository.StationRepository
@@ -28,7 +30,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -67,6 +68,13 @@ abstract class RepositoryModule {
             // 100
             return LruCache(maxSize = 4)
         }
+
+        @Provides
+        @Singleton
+        fun provideLocationRepository(
+            locationApi : LocationApi,
+            local: DataStoreSettingsStorage
+        ): LocationRepository = LocationRepositoryImpl(locationApi = locationApi, local = local)
 
         @Provides
         @Singleton

--- a/app/src/main/java/com/example/sombriyakotlin/data/dto/LocationDto.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/dto/LocationDto.kt
@@ -1,5 +1,6 @@
 package com.example.sombriyakotlin.data.dto
 
+import com.example.sombriyakotlin.domain.model.CreateLocation
 import com.example.sombriyakotlin.domain.model.Localization
 
 data class QueryLocalizationDto(
@@ -8,4 +9,18 @@ data class QueryLocalizationDto(
     val radius_m: Int,
 
     )
+
+data class CreateLocationDto(
+    val latitude: Double,
+    val longitude: Double,
+    val userId: String
+)
+
+
+fun CreateLocation.toDto(): CreateLocationDto= CreateLocationDto(
+    latitude = latitude,
+    longitude = longitude,
+    userId = user_id
+)
+
 fun Localization.toDto(): QueryLocalizationDto = QueryLocalizationDto(latitude, longitude, 3600000)

--- a/app/src/main/java/com/example/sombriyakotlin/data/repository/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/repository/LocationRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.example.sombriyakotlin.data.repository
+
+import android.util.Log
+import com.example.sombriyakotlin.data.datasource.DataStoreSettingsStorage
+import com.example.sombriyakotlin.data.dto.toDto
+import com.example.sombriyakotlin.data.serviceAdapter.LocationApi
+import com.example.sombriyakotlin.domain.model.CreateLocation
+import com.example.sombriyakotlin.domain.repository.LocationRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class LocationRepositoryImpl @Inject constructor(
+    private val locationApi: LocationApi,
+    private val local: DataStoreSettingsStorage
+): LocationRepository {
+    override suspend fun sendCurrentLocation(location: CreateLocation) {
+        val resp = locationApi.createRental(location.toDto())
+        if (!resp.isSuccessful) {
+            val err = resp.errorBody()?.string()
+            Log.e("LocationRepository", "Status ${resp.code()} -> $err")
+        } else {
+            Log.d("LocationRepository","OK, body: ${resp.body()?.string() ?: "empty"}")
+        }
+    }
+
+    override fun isLocationConsentGiven(): Flow<Boolean?> {
+        return local.isLocationConsentGiven()
+    }
+
+    override suspend fun setLocationConsent(sent: Boolean) {
+        return local.setLocationConsent(sent)
+    }
+
+}

--- a/app/src/main/java/com/example/sombriyakotlin/data/repository/RentalRepositoryImpl.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/repository/RentalRepositoryImpl.kt
@@ -2,16 +2,12 @@ package com.example.sombriyakotlin.data.repository
 
 import History
 import android.util.Log
-import com.example.sombriyakotlin.data.api.RentalApi
-import com.example.sombriyakotlin.data.api.UserApi
+import com.example.sombriyakotlin.data.serviceAdapter.RentalApi
 import com.example.sombriyakotlin.data.datasource.RentalLocalDataSource
-import com.example.sombriyakotlin.data.dto.RentalHistoryDto
 import com.example.sombriyakotlin.data.dto.toDomain
-import com.example.sombriyakotlin.data.dto.toDto
 import com.example.sombriyakotlin.data.dto.toEndDto
 import com.example.sombriyakotlin.data.dto.toRequestDto
 import com.example.sombriyakotlin.domain.model.Rental
-import com.example.sombriyakotlin.domain.model.User
 import com.example.sombriyakotlin.domain.repository.RentalRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject

--- a/app/src/main/java/com/example/sombriyakotlin/data/repository/StationRepositoryImpl.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/repository/StationRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.example.sombriyakotlin.data.repository
 
 import android.util.Log
-import com.example.sombriyakotlin.data.api.StationApi
+import com.example.sombriyakotlin.data.serviceAdapter.StationApi
 import com.example.sombriyakotlin.data.cache.LruCache
 import com.example.sombriyakotlin.data.dto.toDomain
 import com.example.sombriyakotlin.data.dto.toDto

--- a/app/src/main/java/com/example/sombriyakotlin/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/repository/UserRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.example.sombriyakotlin.data.repository
 
 import android.util.Log
-import com.example.sombriyakotlin.data.api.UserApi
+import com.example.sombriyakotlin.data.serviceAdapter.UserApi
 import com.example.sombriyakotlin.data.datasource.UserLocalDataSource
 import com.example.sombriyakotlin.data.dto.toDomain
 import com.example.sombriyakotlin.data.dto.toDto

--- a/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/ChatbotApi.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/ChatbotApi.kt
@@ -1,4 +1,4 @@
-package com.example.sombriyakotlin.data.api
+package com.example.sombriyakotlin.data.serviceAdapter
 
 import com.example.sombriyakotlin.data.dto.MessageDto
 import retrofit2.http.Body

--- a/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/LocationApi.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/LocationApi.kt
@@ -1,0 +1,14 @@
+package com.example.sombriyakotlin.data.serviceAdapter
+
+import com.example.sombriyakotlin.data.dto.CreateLocationDto
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface LocationApi {
+
+    @POST("locations")
+    suspend fun createRental(@Body createLocationDto: CreateLocationDto): Response<ResponseBody>
+
+}

--- a/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/RentalApi.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/RentalApi.kt
@@ -1,4 +1,4 @@
-package com.example.sombriyakotlin.data.api
+package com.example.sombriyakotlin.data.serviceAdapter
 
 import com.example.sombriyakotlin.data.dto.EndRentalDto
 import com.example.sombriyakotlin.data.dto.RentalDto

--- a/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/StationApi.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/StationApi.kt
@@ -1,4 +1,4 @@
-package com.example.sombriyakotlin.data.api
+package com.example.sombriyakotlin.data.serviceAdapter
 
 import com.example.sombriyakotlin.data.dto.QueryLocalizationDto
 import com.example.sombriyakotlin.data.dto.StationDto

--- a/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/UserApi.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/data/serviceAdapter/UserApi.kt
@@ -1,4 +1,4 @@
-package com.example.sombriyakotlin.data.api
+package com.example.sombriyakotlin.data.serviceAdapter
 
 import com.example.sombriyakotlin.data.dto.CreateUserDto
 import com.example.sombriyakotlin.data.dto.DistanceDto

--- a/app/src/main/java/com/example/sombriyakotlin/domain/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/domain/di/UseCaseModule.kt
@@ -2,6 +2,7 @@ package com.example.sombriyakotlin.domain.di
 
 import com.example.sombriyakotlin.domain.repository.ChatbotRepository
 import com.example.sombriyakotlin.domain.repository.HistoryRepository
+import com.example.sombriyakotlin.domain.repository.LocationRepository
 import com.example.sombriyakotlin.domain.repository.NetworkRepository
 import com.example.sombriyakotlin.domain.repository.StationRepository
 import com.example.sombriyakotlin.domain.repository.RentalRepository
@@ -13,6 +14,10 @@ import com.example.sombriyakotlin.domain.usecase.chatbot.SendMessageUseCase
 import com.example.sombriyakotlin.domain.usecase.history.GetHistory
 import com.example.sombriyakotlin.domain.usecase.history.HistoryUseCases
 import com.example.sombriyakotlin.domain.usecase.history.SaveHistory
+import com.example.sombriyakotlin.domain.usecase.location.IsLocationConsentGiven
+import com.example.sombriyakotlin.domain.usecase.location.LocationUseCases
+import com.example.sombriyakotlin.domain.usecase.location.SendCurrentLocation
+import com.example.sombriyakotlin.domain.usecase.location.SetLocationConsent
 import com.example.sombriyakotlin.domain.usecase.stations.GetStationsUseCase
 import com.example.sombriyakotlin.domain.usecase.stations.StationsUseCases
 import com.example.sombriyakotlin.domain.usecase.rental.CreateRentalUseCase
@@ -75,6 +80,16 @@ object UseCaseModule {
         return StationsUseCases(
         GetStationsUseCase(repo),
             GetStationByTagUseCase(repo)
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideLocationUseCases(repo: LocationRepository): LocationUseCases{
+        return LocationUseCases(
+            sendCurrentLocation = SendCurrentLocation(repo),
+            isLocationConsentGiven = IsLocationConsentGiven(repo),
+            setLocationConsent = SetLocationConsent(repo)
         )
     }
 

--- a/app/src/main/java/com/example/sombriyakotlin/domain/model/Localization.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/domain/model/Localization.kt
@@ -4,3 +4,9 @@ data class Localization(
     val latitude: Double,
     val longitude: Double
 )
+
+data class CreateLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val user_id: String
+)

--- a/app/src/main/java/com/example/sombriyakotlin/domain/repository/LocationRepository.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/domain/repository/LocationRepository.kt
@@ -1,0 +1,16 @@
+package com.example.sombriyakotlin.domain.repository
+
+import com.example.sombriyakotlin.domain.model.CreateLocation
+
+
+interface LocationRepository {
+
+    suspend fun sendCurrentLocation(location: CreateLocation)
+    // Lógica para obtener la ubicación actual
+
+    //persistir
+    fun isLocationConsentGiven(): kotlinx.coroutines.flow.Flow<Boolean?>
+
+    suspend fun setLocationConsent(sent: Boolean)
+
+}

--- a/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/IsLocationConsentGiven.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/IsLocationConsentGiven.kt
@@ -1,0 +1,8 @@
+package com.example.sombriyakotlin.domain.usecase.location
+
+import com.example.sombriyakotlin.domain.repository.LocationRepository
+import javax.inject.Inject
+
+class IsLocationConsentGiven @Inject constructor(private val repo: LocationRepository) {
+    operator fun invoke() = repo.isLocationConsentGiven()
+}

--- a/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/LocationUseCases.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/LocationUseCases.kt
@@ -1,0 +1,8 @@
+package com.example.sombriyakotlin.domain.usecase.location
+
+data class LocationUseCases (
+    val sendCurrentLocation: SendCurrentLocation,
+
+    val isLocationConsentGiven: IsLocationConsentGiven,
+    val setLocationConsent: SetLocationConsent
+)

--- a/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/SendCurrentLocation.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/SendCurrentLocation.kt
@@ -1,0 +1,10 @@
+package com.example.sombriyakotlin.domain.usecase.location
+
+import com.example.sombriyakotlin.domain.model.CreateLocation
+import com.example.sombriyakotlin.domain.repository.LocationRepository
+import javax.inject.Inject
+
+class SendCurrentLocation @Inject constructor(private val repo: LocationRepository) {
+    suspend operator fun invoke(location:CreateLocation) = repo.sendCurrentLocation(location)
+
+}

--- a/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/SetLocationConsent.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/domain/usecase/location/SetLocationConsent.kt
@@ -1,0 +1,8 @@
+package com.example.sombriyakotlin.domain.usecase.location
+
+import com.example.sombriyakotlin.domain.repository.LocationRepository
+import javax.inject.Inject
+
+class SetLocationConsent @Inject constructor(private val repo: LocationRepository) {
+    suspend operator fun invoke(sent: Boolean) = repo.setLocationConsent(sent)
+}

--- a/app/src/main/java/com/example/sombriyakotlin/ui/account/ProfileScreen.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/account/ProfileScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -17,6 +18,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ModalDrawer
+import androidx.compose.material.Switch
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -25,6 +29,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -93,6 +99,9 @@ fun ContentCard(
 
     var loggingOut by remember { mutableStateOf(false) }
 
+    val consent by viewModel.consentState.collectAsState() // Boolean? (null = no preguntado)
+
+
     if (loggingOut) {
         LaunchedEffect (Unit) {
             viewModel.logout()
@@ -123,14 +132,47 @@ fun ContentCard(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // === NOMBRE ===
-        Text("¡Bienvenido ${currentName}!", fontWeight = FontWeight.Bold, modifier = Modifier.padding(vertical = 16.dp), fontSize = 24.sp)
+        Text("¡Hola ${currentName}!", fontWeight = FontWeight.Bold, modifier = Modifier.padding(vertical = 16.dp), fontSize = 24.sp)
 
         WaterLevelCircle(percentage = percentage, distance = userDistance)
 
-
+        // === EMAIL ===
+        OutlinedTextField(
+            value = currentMail,
+            onValueChange = {},
+            readOnly = true,
+            shape = RoundedCornerShape(24.dp),
+            prefix = {
+                Text(
+                    "Email",
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(end = 130.dp)
+                )
+            },
+            trailingIcon = {
+                IconButton(onClick = { openDialogMail = true }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.arrow),
+                        contentDescription = "Modificar información",
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            },
+            colors = TextFieldDefaults.colors(
+                disabledContainerColor  = colorResource(R.color.secondary),
+                focusedContainerColor   = colorResource(R.color.secondary),
+                unfocusedContainerColor = colorResource(R.color.secondary),
+                focusedTextColor        = colorResource(R.color.gray),
+                unfocusedTextColor      = colorResource(R.color.gray),
+                focusedIndicatorColor   = colorResource(R.color.primary),
+                unfocusedIndicatorColor = colorResource(R.color.primary)
+            ),
+            modifier = Modifier.fillMaxWidth(),
+            enabled = false
+        )
         // === CONTRASEÑA ===
         OutlinedTextField(
-            value = currentPassword,
+            value = "........",
             onValueChange = {},
             readOnly = true,
             shape = RoundedCornerShape(24.dp),
@@ -167,42 +209,34 @@ fun ContentCard(
                 .clickable(
                     indication = null,
                     interactionSource = remember { MutableInteractionSource() }
-                ) { openDialogPassword = true }
+                ) { openDialogPassword = true },
+            enabled = false
         )
 
-        // === EMAIL ===
-        OutlinedTextField(
-            value = currentMail,
-            onValueChange = {},
-            readOnly = true,
-            shape = RoundedCornerShape(24.dp),
-            prefix = {
-                Text(
-                    "Email",
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(end = 130.dp)
-                )
-            },
-            trailingIcon = {
-                IconButton(onClick = { openDialogMail = true }) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.arrow),
-                        contentDescription = "Modificar información",
-                        modifier = Modifier.size(24.dp)
-                    )
-                }
-            },
-            colors = TextFieldDefaults.colors(
-                disabledContainerColor  = colorResource(R.color.secondary),
-                focusedContainerColor   = colorResource(R.color.secondary),
-                unfocusedContainerColor = colorResource(R.color.secondary),
-                focusedTextColor        = colorResource(R.color.gray),
-                unfocusedTextColor      = colorResource(R.color.gray),
-                focusedIndicatorColor   = colorResource(R.color.primary),
-                unfocusedIndicatorColor = colorResource(R.color.primary)
-            ),
-            modifier = Modifier.fillMaxWidth()
+        Row (
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
         )
+        {
+            Text("¿Enviar ubicación al abrir la app?")
+            Switch(
+            checked = consent == true,
+            onCheckedChange = { viewModel.setLocationConsent(it) },
+                thumbContent = if (consent == true) {
+                    {
+                        Icon(
+                            imageVector = Icons.Filled.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(SwitchDefaults.IconSize),
+                        )
+                    }
+                } else {
+                    null
+                }
+            )
+        }
+
         //
         Button(
             onClick = { loggingOut = true },

--- a/app/src/main/java/com/example/sombriyakotlin/ui/account/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/account/ProfileScreenViewModel.kt
@@ -4,18 +4,22 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.sombriyakotlin.domain.model.User
+import com.example.sombriyakotlin.domain.usecase.location.LocationUseCases
 import com.example.sombriyakotlin.domain.usecase.user.UserUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ProfileScreenViewModel @Inject constructor(
-    private val userUseCases: UserUseCases
+    private val userUseCases: UserUseCases,
+    private val locationUseCases: LocationUseCases
 ) : ViewModel() {
 
     sealed class ProfileState {
@@ -33,6 +37,10 @@ class ProfileScreenViewModel @Inject constructor(
     init {
         loadInitialData()
     }
+
+    val consentState = locationUseCases.isLocationConsentGiven()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null) // null = not asked
+
 
     private fun loadInitialData() {
         viewModelScope.launch {
@@ -76,5 +84,11 @@ class ProfileScreenViewModel @Inject constructor(
 
     suspend fun logout() {
         userUseCases.closeSessionUseCase()
+    }
+
+    fun setLocationConsent(given: Boolean) {
+        viewModelScope.launch {
+            locationUseCases.setLocationConsent(given)
+        }
     }
 }

--- a/app/src/main/java/com/example/sombriyakotlin/ui/account/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/account/login/LoginScreen.kt
@@ -206,7 +206,7 @@ fun LoginScreen(
                         modifier = Modifier.fillMaxWidth(),
                         colors= ButtonColors(Color(0xFF001242),Color(0xFF001242),Color(0xFF001242),Color(0xFF001242)),
                         onClick = {viewModel.loginUser(email,pass)},
-                        enabled = !isLoading)
+                        enabled = !isLoading && email.isNotBlank() && pass.isNotBlank())
                     {
                         if (isLoading) {
                             CircularProgressIndicator(

--- a/app/src/main/java/com/example/sombriyakotlin/ui/account/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/account/login/LoginViewModel.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val userUseCases: UserUseCases,
-    private val rentalUseCases: RentalUseCases
+    private val rentalUseCases: RentalUseCases,
 ) : ViewModel() {
 
     // Clase sellada para manejar los estados de la UI
@@ -43,7 +43,7 @@ class LoginViewModel @Inject constructor(
                 upDateRentalLocal()
             } catch (e: Exception) {
                 Log.e("LoginViewModel", "Error en el login: ${e.message}", e)
-                _loginState.value = LoginState.Error("Error en el login: ${e.message}")
+                _loginState.value = LoginState.Error("Error en el login: Compruebe sus credenciales")
             }
         }
     }
@@ -60,7 +60,7 @@ class LoginViewModel @Inject constructor(
                     upDateRentalLocal()
                 }else {
                     Log.w("LoginViewModel", "Credential is not of type Google ID!")
-                    _loginState.value = LoginState.Error("Error inseperado en el login 2000")
+                    _loginState.value = LoginState.Error("Error inseperado en el login")
 
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/example/sombriyakotlin/ui/layout/PedometerCounter.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/layout/PedometerCounter.kt
@@ -7,7 +7,9 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -20,6 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 
@@ -58,7 +62,19 @@ fun PedometerCounter(
     }
 
     if (running){
-        Text(text = "Pasos: $count", style = MaterialTheme.typography.headlineMedium, modifier = Modifier.fillMaxWidth())
+        AnimatedContent(
+            targetState = count,
+            label = ""
+        ) { value ->
+            Text(
+                text = "Pasos: $value",
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                textAlign = TextAlign.Center
+            )
+        }
     }
     else {
         //Button({ running = true; viewModel.startPedometer() }) { }

--- a/app/src/main/java/com/example/sombriyakotlin/ui/popup/PopUp.kt
+++ b/app/src/main/java/com/example/sombriyakotlin/ui/popup/PopUp.kt
@@ -26,3 +26,20 @@ fun SomenthingWentWrongPopUp(
     )
 }
 
+@Composable
+fun ConsentDialog(onAllow: () -> Unit, onDeny: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = { /* evitar dismiss si quieres forzar respuesta; o llamar onDeny */ },
+        title = { Text("Enviar ubicación") },
+        text = {
+            Text("¿Deseas enviar tu ubicación al abrir la app? Se usará para mejorar la aplicación y se mantendrá privada.")
+        },
+        confirmButton = {
+            TextButton(onClick = onAllow) { Text("Permitir") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDeny) { Text("No permitir") }
+        }
+    )
+}
+


### PR DESCRIPTION
*   Introduce `LocationRepository`, `LocationApi`, and associated Use Cases to handle sending user location.
*   Implement `DataStoreSettingsStorage` to persist location consent status (`isLocationConsentGiven`).
*   Update `MainScreen` to display `ConsentDialog` on startup if consent has not been requested.
*   Add toggle switch to `ProfileScreen` to allow users to modify location settings.
*   Refactor API interfaces from `data/api` to `data/serviceAdapter`.
*   Enhance `PedometerCounter` with `AnimatedContent` for step updates.
*   Update `LoginScreen` validation to disable the button on empty fields and improve error messaging.
